### PR TITLE
1、新增K线图 Y轴支持小数展示

### DIFF
--- a/HSStockChart/Classes/DrawLayerProtocol/HSDrawLayerProtocol.swift
+++ b/HSStockChart/Classes/DrawLayerProtocol/HSDrawLayerProtocol.swift
@@ -127,7 +127,8 @@ extension HSDrawLayerProtocol {
 
         if model.isKind(of: HSKLineModel.self) {
             let entity = model as! HSKLineModel
-            yAxisMarkString = entity.close.hschart.toStringWithFormat(".2")
+			let formatStr = "." + "\(getZeroCount(value: entity.close))"
+			yAxisMarkString = entity.close.hschart.toStringWithFormat(formatStr)
             bottomMarkerString = entity.date.hschart.toDate("yyyyMMddHHmmss")?.hschart.toString("MM-dd") ?? ""
             volumeMarkerString = entity.volume.hschart.toStringWithFormat(".2")
 
@@ -225,4 +226,18 @@ extension HSDrawLayerProtocol {
         
         return CGSize(width: width, height: height)
     }
+	func getZeroCount(value:CGFloat) -> Int{
+		if value <= 0 {
+			return 0
+		}
+		let str = NSNumber.init(value: Double(value)).stringValue
+		if !str.contains(".") {
+			return 0
+		}
+		let arr = str.components(separatedBy: ".")
+		guard let subStr = arr.last else {
+			return 0
+		}
+		return subStr.lengthOfBytes(using: String.Encoding.utf8)
+	}
 }

--- a/HSStockChart/Classes/KLineChart/HSKLineUpFrontView.swift
+++ b/HSStockChart/Classes/KLineChart/HSKLineUpFrontView.swift
@@ -55,9 +55,11 @@ class HSKLineUpFrontView: UIView, HSDrawLayerProtocol {
     }
     
     func configureAxis(max: CGFloat, min: CGFloat, maxVol: CGFloat) {
-        let maxPriceStr = max.hschart.toStringWithFormat(".2")
-        let minPriceStr = min.hschart.toStringWithFormat(".2")
-        let midPriceStr = ((max + min) / 2).hschart.toStringWithFormat(".2")
+		
+		let formatStr = "." + getFormatCount(max: max, min: min).description
+        let maxPriceStr = max.hschart.toStringWithFormat(formatStr)
+        let minPriceStr = min.hschart.toStringWithFormat(formatStr)
+        let midPriceStr = ((max + min) / 2).hschart.toStringWithFormat(formatStr)
         let maxVolStr = maxVol.hschart.toStringWithFormat(".2")
         maxMark.string = maxPriceStr
         minMark.string = minPriceStr
@@ -89,4 +91,26 @@ class HSKLineUpFrontView: UIView, HSDrawLayerProtocol {
     func removeCrossLine() {
         self.corssLineLayer.removeFromSuperlayer()
     }
+	func getFormatCount(max: CGFloat,min: CGFloat) -> Int{
+		
+		var count: Int = 0
+		count = getZeroCount(value: max)
+		count = getZeroCount(value: min) > count ? getZeroCount(value: min) : count
+		
+		return count
+	}
+	func getZeroCount(value:CGFloat) -> Int{
+		if value <= 0 {
+			return 0
+		}
+		let str = NSNumber.init(value: Double(value)).stringValue
+		if !str.contains(".") {
+			return 0
+		}
+		let arr = str.components(separatedBy: ".")
+		guard let subStr = arr.last else {
+			return 0
+		}
+		return subStr.lengthOfBytes(using: String.Encoding.utf8)
+	}
 }


### PR DESCRIPTION
原来默认是保留两位小数点，对于一些原本就很小的值不够精确。添加了判断小数点后具体几位的方法，更精确的展示数据